### PR TITLE
Check if isCommonJsEnv is true instead of truthy

### DIFF
--- a/src/stringformat.js
+++ b/src/stringformat.js
@@ -164,7 +164,7 @@
     }
 
     var ensureCultureLoaded;
-    if (isCommonJsEnv) {
+    if (isCommonJsEnv === true) {
         ensureCultureLoaded = function(key) {
             if (!(key in cultures)) {
                 cultures[key] = false;


### PR DESCRIPTION
Use strict true check for isCommonJsEnv variable.

This is necessary because in an amd / requirejs context the isCommonJsEnv will be set to the"require" function by the define call. The  check will pass which leads to a synchronous module load error in a requirejs context.